### PR TITLE
updates based on testing (read: flailing)

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -654,17 +654,18 @@ class CollectionState():
             if new_region in rrp:
                 bc.remove(connection)
             elif connection.can_reach(self):
-                assert new_region, f"tried to search through an Entrance \"{connection}\" with no Region"
-                rrp.add(new_region)
-                bc.remove(connection)
-                bc.update(new_region.exits)
-                queue.extend(new_region.exits)
-                self.path[new_region] = (new_region.name, self.path.get(connection, None))
+                if new_region:
+                # assert new_region, f"tried to search through an Entrance \"{connection}\" with no Region"
+                    rrp.add(new_region)
+                    bc.remove(connection)
+                    bc.update(new_region.exits)
+                    queue.extend(new_region.exits)
+                    self.path[new_region] = (new_region.name, self.path.get(connection, None))
 
-                # Retry connections if the new region can unblock them
-                for new_entrance in self.multiworld.indirect_connections.get(new_region, set()):
-                    if new_entrance in bc and new_entrance not in queue:
-                        queue.append(new_entrance)
+                    # Retry connections if the new region can unblock them
+                    for new_entrance in self.multiworld.indirect_connections.get(new_region, set()):
+                        if new_entrance in bc and new_entrance not in queue:
+                            queue.append(new_entrance)
 
     def copy(self) -> CollectionState:
         ret = CollectionState(self.multiworld)

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -634,7 +634,7 @@ class CollectionState():
             for item in items:
                 self.collect(item, True)
 
-    def update_reachable_regions(self, player: int):
+    def update_reachable_regions(self, player: int, allow_partial_entrances: bool = False):
         self.stale[player] = False
         rrp = self.reachable_regions[player]
         bc = self.blocked_connections[player]
@@ -654,18 +654,21 @@ class CollectionState():
             if new_region in rrp:
                 bc.remove(connection)
             elif connection.can_reach(self):
-                if new_region:
-                # assert new_region, f"tried to search through an Entrance \"{connection}\" with no Region"
-                    rrp.add(new_region)
-                    bc.remove(connection)
-                    bc.update(new_region.exits)
-                    queue.extend(new_region.exits)
-                    self.path[new_region] = (new_region.name, self.path.get(connection, None))
+                if not allow_partial_entrances:
+                    assert new_region, f"tried to search through an Entrance \"{connection}\" with no Region"
+                else:
+                    if not new_region:
+                        break
+                rrp.add(new_region)
+                bc.remove(connection)
+                bc.update(new_region.exits)
+                queue.extend(new_region.exits)
+                self.path[new_region] = (new_region.name, self.path.get(connection, None))
 
-                    # Retry connections if the new region can unblock them
-                    for new_entrance in self.multiworld.indirect_connections.get(new_region, set()):
-                        if new_entrance in bc and new_entrance not in queue:
-                            queue.append(new_entrance)
+                # Retry connections if the new region can unblock them
+                for new_entrance in self.multiworld.indirect_connections.get(new_region, set()):
+                    if new_entrance in bc and new_entrance not in queue:
+                        queue.append(new_entrance)
 
     def copy(self) -> CollectionState:
         ret = CollectionState(self.multiworld)
@@ -794,8 +797,8 @@ class Entrance:
         self.er_group = er_group
         self.er_type = er_type
 
-    def can_reach(self, state: CollectionState) -> bool:
-        if self.parent_region.can_reach(state) and self.access_rule(state):
+    def can_reach(self, state: CollectionState, allow_partial_entrances: bool = False) -> bool:
+        if self.parent_region.can_reach(state, allow_partial_entrances) and self.access_rule(state):
             if not self.hide_path and not self in state.path:
                 state.path[self] = (self.name, state.path.get(self.parent_region, (self.parent_region.name, None)))
             return True
@@ -925,9 +928,9 @@ class Region:
 
     exits = property(get_exits, set_exits)
 
-    def can_reach(self, state: CollectionState) -> bool:
+    def can_reach(self, state: CollectionState, allow_partial_entrances: bool = False) -> bool:
         if state.stale[self.player]:
-            state.update_reachable_regions(self.player)
+            state.update_reachable_regions(self.player, allow_partial_entrances)
         return self in state.reachable_regions[self.player]
 
     @property

--- a/EntranceRando.py
+++ b/EntranceRando.py
@@ -40,17 +40,21 @@ class EntranceLookup:
     # todo - investigate whether this might leak memory (holds references to Entrances)?
     @staticmethod
     @functools.cache
-    def _is_dead_end(entrance: Entrance):
+    def _is_dead_end(entrance: Entrance, visited_regions=""):
         """
         Checks whether a entrance is an unconditional dead end, that is, no matter what you have,
         it will never lead to new randomizable exits.
         """
-
         # obviously if this is an unpaired exit, then leads to unpaired exits!
         if not entrance.connected_region:
             return False
+        for region in visited_regions.split("::"):
+            if region == entrance.connected_region.name:
+                return True
+            else:
+                visited_regions += "::" + entrance.connected_region.name
         # if the connected region has no exits, it's a dead end. otherwise its exits must all be dead ends.
-        return not entrance.connected_region.exits or all(EntranceLookup._is_dead_end(exit)
+        return not entrance.connected_region.exits or all(EntranceLookup._is_dead_end(exit, visited_regions)
                                                           for exit in entrance.connected_region.exits
                                                           if exit.name != entrance.name)
 
@@ -120,11 +124,11 @@ class ERPlacementState:
         starting_entrance_name = None
         if isinstance(start, Entrance):
             starting_entrance_name = start.name
-            q.put(start.parent_region)
+            q.put(start.connected_region)
         else:
             q.put(start)
 
-        while q:
+        while not q.empty():
             region = q.get()
             if region in self.placed_regions:
                 continue
@@ -146,7 +150,7 @@ class ERPlacementState:
                 elif exit.connected_region not in self.placed_regions:
                     # traverse unseen static connections
                     if exit.can_reach(self.collection_state):
-                        q.put(exit)
+                        q.put(exit.connected_region)
                     else:
                         self._pending_exits.add(exit)
 
@@ -255,7 +259,7 @@ def randomize_entrances(
         # todo - this doesn't prioritize placing new rooms like the original did;
         #        that's problematic because early loops would lead to failures
         # this is needed to reduce bias; otherwise newer exits are prioritized
-        rng.shuffle(state._placeable_exits)
+        # rng.shuffle(state._placeable_exits)
         source_exit = state._placeable_exits.pop()
 
         target_groups = get_target_groups(source_exit.er_group)
@@ -286,6 +290,7 @@ def randomize_entrances(
         # none of the existing targets can pair to the existing sources. Since dead ends will never add new sources
         # this means the current targets can never be paired (in most cases)
         # todo - investigate ways to prevent this case
+        return state
         raise Exception("Unable to place all non-dead-end entrances with available source exits")
 
     # anything we couldn't place before might be placeable now


### PR DESCRIPTION
update: i got it to *kinda* run
but entrance.can_reach sometimes just returns: no (seems like access rules, but i didn't even set any anywhere)
and partially because of this, sweep pending never marks new entrances as placeable so we never connect more than the initial scene's transitions

some changes i made along the way for better or for worse are:
* CollectionState update_reachable_regions() was dying because sometimes there just wasn't a connection.connected_region (because it wasn't connected yet, duh) so i threw a simple `if new region:` and let it drop out if the entrance wasn't connected,, not sure if that was the right thing to do but i didn't fully understand what the method was doing and this got me to not crash so i went with it for now
* EntranceLookup _is_dead_end() was looping forever in some regions, so i added a list (that i had to make into a :: delimated string because my list wasn't hashable, so probably not the best solution) that marks which regions were visited so it can short circut True if the connected region has already been traversed in the recursion loop
* ERPlacementState place() is putting the parent region of the entrance into the queue when by definition the entrances that are passed into it will never have a parent, only a connected region, so swapped that to connected_region
* ERPlacementState place() is doing `while q` again, which seems to freeze up so i swapped it back to `while not q.empty()`
* ERPlacementState place() is putting back into the queue `exit` when the exit is reachable, but since the exit to region handling is done outside of the queue is breaking, so swapped that to `q.put(exit.connected_region)` instead
* randomize_entrances() calls `rng.shuffle(state._placeable_exits)` which is apparently illegal, i just commented it out to move forward

i also returned instead of throwing an exception when unable to place non-dead-entrances because i just wanted output instead of a failure