### PR TITLE
CommonClient: Don't retry connection when connection details are invalid

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -733,8 +733,10 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
     elif cmd == 'ConnectionRefused':
         errors = args["errors"]
         if 'InvalidSlot' in errors:
+            ctx.disconnected_intentionally = True
             ctx.event_invalid_slot()
         elif 'InvalidGame' in errors:
+            ctx.disconnected_intentionally = True
             ctx.event_invalid_game()
         elif 'IncompatibleVersion' in errors:
             raise Exception('Server reported your client version as incompatible')


### PR DESCRIPTION

## What is this fixing or adding?
make invalid slot and invalid game connections be disconnect intentionally so they don't try to retry while you're trying to update the connection details
Errors are not impacted, it just doesn't auto retry when the connection details are invalid.

## How was this tested?
connecting to a live server with:
* an invalid slot name with format `slotName:@url:port`
* an invalid slot name with format `url:port` and passing in an invalid slot name when prompted
* a valid slot name using both formats on a different game client (Undertale client connecting to a Tunic slot)

All of which showed a correct error message and did not try and reconnect with the same invalid connection details.

## If this makes graphical changes, please attach screenshots.
